### PR TITLE
Input prompt with default value

### DIFF
--- a/cutie.py
+++ b/cutie.py
@@ -94,6 +94,22 @@ def secure_input(prompt: str) -> str:
     return getpass.getpass(prompt + " ")
 
 
+def default_input(prompt: str, default: str) -> str:
+    """Get an input with a default value, if user leaves input empty.
+
+    Args:
+        prompt (str): The prompt asking the user to input
+        default (str): The default value if left empty
+
+        Returns:
+            str: The user input or default if empty
+    """
+    user_input = input(f"{prompt} ({default}): ")
+    if user_input == "":
+        return default
+    return user_input
+
+
 def select(
     options: List[str],
     caption_indices: Optional[List[int]] = None,


### PR DESCRIPTION
A small addition that simplifies input with a provided default value. E.g. if you want to provide a default file path, but also want give the user the option to change that file:

```python
file_path = cutie.default_input("Save content as", "/home/user/content.txt")
print(file_path)
```

results in:
```
$ Save content as (/home/user/content.txt): anotherfile.txt
$ anotherfile.txt
```
or
```
$ Save content as (/home/user/content.txt): <User presses enter without typing>
$ /home/user/content.txt
```

I hope the use-case is clear. I have never worked before with the mock-framework for tests and therefore could not provide some tests cases yet. Also there are many options for customization which are not yet implemented, e.g. changing how the default value is presented and how the prompt is displayed.